### PR TITLE
Replace MAINTAINER command with LABEL

### DIFF
--- a/ci-deployer/Dockerfile
+++ b/ci-deployer/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-cli
 
-Maintainer Mriyam Tamuli <mbtamuli@gmail.com>
+LABEL maintainer="Mriyam Tamuli <mbtamuli@gmail.com>"
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
 && echo "date.timezone=Asia/Kolkata" > "$PHP_INI_DIR/conf.d/date_timezone.ini"

--- a/nginx-build/Dockerfile
+++ b/nginx-build/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-Maintainer Mriyam Tamuli <mbtamuli@gmail.com>
+LABEL maintainer="Mriyam Tamuli <mbtamuli@gmail.com>"
 
 RUN apt update && apt install -qqy wget
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-MAINTAINER Mriyam Tamuli <mbtamuli@gmail.com>
+LABEL maintainer="Mriyam Tamuli <mbtamuli@gmail.com>"
 
 RUN export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver "hkp://pgp.mit.edu" --recv-keys '3050AC3CD2AE6F03' \

--- a/php/7.1/fpm/Dockerfile
+++ b/php/7.1/fpm/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-fpm
 
-MAINTAINER Mriyam Tamuli <mbtamuli@gmail.com>
+LABEL maintainer="Mriyam Tamuli <mbtamuli@gmail.com>"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
As it is deprecated since Docker v1.13.0, it's better to use LABEL command to display the name and email id of maintainer.

https://github.com/moby/moby/pull/25466

https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated