### PR TITLE
Add dnsmasq Dockerfile

### DIFF
--- a/dnsmasq/Dockerfile
+++ b/dnsmasq/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:edge
+LABEL maintainer="Dharmin Shah <dharminshah175@gmail.com>"
+
+RUN apk update \
+    && apk --no-cache add dnsmasq
+RUN mkdir -p /etc/default/
+RUN echo -e "ENABLED=1\nIGNORE_RESOLVCONF=yes" > /etc/default/dnsmasq
+RUN echo "addn-hosts=/etc/ee4_hosts" > /etc/dnsmasq.d/ee.conf
+ENTRYPOINT ["dnsmasq","--no-daemon"]

--- a/dnsmasq/Dockerfile
+++ b/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.7
 LABEL maintainer="Dharmin Shah <dharminshah175@gmail.com>"
 
 RUN apk update \


### PR DESCRIPTION
Mount any hosts file to /etc/ee4_hosts

Eg.
```
docker run \
    --name dnsmasq \
    -d \
    -p 127.0.0.1:53:53/udp \
    -v /home/rtcamp/.ee4/ee4_hosts:/etc/ee4_hosts \
    --restart always \
    rtcamp/dnsmasq
```

Add hosts like simple /etc/hosts file to `ee4_hosts`

Eg.
```
127.0.0.1 site1.test
127.0.0.1 site2.test
```

After updating the `ee4_hosts` file send SIGHUP to dnsmasq  to reload the hosts file

Eg.
```
docker exec dnsmasq kill -1 1
```